### PR TITLE
base: preference seekbar widgets should follow the rules

### DIFF
--- a/core/res/res/layout/preference_widget_seekbar.xml
+++ b/core/res/res/layout/preference_widget_seekbar.xml
@@ -23,6 +23,7 @@
     android:paddingEnd="?android:attr/scrollbarSize">
 
     <LinearLayout
+        android:id="@+id/icon_frame"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:gravity="center"

--- a/core/res/res/layout/preference_widget_seekbar_material.xml
+++ b/core/res/res/layout/preference_widget_seekbar_material.xml
@@ -24,6 +24,7 @@
     android:paddingEnd="?attr/listPreferredItemPaddingEnd">
 
     <LinearLayout
+        android:id="@+id/icon_frame"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:gravity="center"


### PR DESCRIPTION
if no icon is set the icon space should be removed
but that wont work if this id is not set

Change-Id: I94e638a396a31e8209a1c218e7b55ebfb564a44f